### PR TITLE
CI: enforce branch protections on merge to main-clean

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,12 @@
 name: CI
+
 on:
-  push:
-    branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [main-clean]
+  push:
+    branches: [main-clean]
+  workflow_dispatch:
+
 jobs:
   precommit:
     runs-on: ubuntu-latest
@@ -11,11 +14,25 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
-      - run: pip install --upgrade pip pre-commit
+          python-version: '3.12'
+      - run: pipx install pre-commit
       - run: pre-commit run --all-files
+
   build-and-test:
+    needs: precommit
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: echo "Build and test placeholder"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install MkDocs deps
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements-mkdocs.txt ]; then
+            pip install -r requirements-mkdocs.txt
+          else
+            pip install "mkdocs>=1.6" "mkdocs-material>=9.5" mike "mkdocs-git-revision-date-localized-plugin>=1.2"
+          fi
+      - name: Build docs
+        run: mkdocs build --strict

--- a/.github/workflows/protect-branches.yml
+++ b/.github/workflows/protect-branches.yml
@@ -1,0 +1,95 @@
+name: Protect branches
+
+on:
+  push:
+    branches: [main-clean]
+  workflow_dispatch:
+  schedule:
+    - cron: '17 3 * * *'  # ежедневная самопроверка (UTC)
+
+permissions:
+  contents: read
+  pull-requests: read
+  actions: read
+  administration: write
+
+concurrency:
+  group: protect-branches
+  cancel-in-progress: false
+
+jobs:
+  protect:
+    if: github.ref == 'refs/heads/main-clean' || github.event_name != 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply branch protections
+        env:
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAIN: main-clean
+          LEG: main-legacy
+        run: |
+          set -euo pipefail
+          HDR='Accept: application/vnd.github+json'
+
+          echo "🔐 Apply protections for $MAIN"
+          gh api -X PUT "repos/$OWNER/$REPO/branches/$MAIN/protection" -H "$HDR" --input - <<'JSON'
+          {
+            "required_status_checks": {
+              "strict": true,
+              "checks": [
+                {"context":"precommit"},
+                {"context":"build-and-test"}
+              ]
+            },
+            "enforce_admins": true,
+            "required_pull_request_reviews": {
+              "required_approving_review_count": 1,
+              "dismiss_stale_reviews": true,
+              "require_code_owner_reviews": false
+            },
+            "restrictions": null,
+            "required_linear_history": true,
+            "allow_force_pushes": false,
+            "allow_deletions": false,
+            "required_conversation_resolution": { "enabled": true }
+          }
+          JSON
+          gh api -X POST "repos/$OWNER/$REPO/branches/$MAIN/protection/required_signatures" -H "$HDR" >/dev/null || true
+
+          echo "🧊 Try lock $LEG"
+          gh api -X PUT "repos/$OWNER/$REPO/branches/$LEG/protection" -H "$HDR" --input - <<'JSON'
+          {
+            "required_status_checks": null,
+            "enforce_admins": true,
+            "required_pull_request_reviews": null,
+            "restrictions": null,
+            "required_linear_history": true,
+            "allow_force_pushes": false,
+            "allow_deletions": false,
+            "required_conversation_resolution": { "enabled": true },
+            "lock_branch": { "enabled": true }
+          }
+          JSON
+          gh api -X POST "repos/$OWNER/$REPO/branches/$LEG/protection/required_signatures" -H "$HDR" >/dev/null || true
+
+          LOCK=$(gh api "repos/$OWNER/$REPO/branches/$LEG/protection" -H "$HDR" --jq '.lock_branch.enabled' || echo false)
+          if [ "$LOCK" != "true" ]; then
+            echo "⚠️ lock_branch недоступен — fallback"
+            gh api -X PUT "repos/$OWNER/$REPO/branches/$LEG/protection" -H "$HDR" --input - <<'JSON'
+            {
+              "required_status_checks": { "strict": true, "checks": [ {"context":"lock-branch-sentinel"} ] },
+              "enforce_admins": true,
+              "required_pull_request_reviews": { "required_approving_review_count": 999 },
+              "restrictions": null,
+              "required_linear_history": true,
+              "allow_force_pushes": false,
+              "allow_deletions": false,
+              "required_conversation_resolution": { "enabled": true }
+            }
+            JSON
+            gh api -X POST "repos/$OWNER/$REPO/branches/$LEG/protection/required_signatures" -H "$HDR" >/dev/null || true
+          fi
+
+          echo "✅ Branch protections updated" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/protect-branches.yml
+++ b/.github/workflows/protect-branches.yml
@@ -53,7 +53,7 @@ jobs:
             "required_linear_history": true,
             "allow_force_pushes": false,
             "allow_deletions": false,
-            "required_conversation_resolution": { "enabled": true }
+            "required_conversation_resolution": true
           }
           JSON
           gh api -X POST "repos/$OWNER/$REPO/branches/$MAIN/protection/required_signatures" -H "$HDR" >/dev/null || true
@@ -68,8 +68,8 @@ jobs:
             "required_linear_history": true,
             "allow_force_pushes": false,
             "allow_deletions": false,
-            "required_conversation_resolution": { "enabled": true },
-            "lock_branch": { "enabled": true }
+            "required_conversation_resolution": true,
+            "lock_branch": true
           }
           JSON
           gh api -X POST "repos/$OWNER/$REPO/branches/$LEG/protection/required_signatures" -H "$HDR" >/dev/null || true
@@ -86,7 +86,7 @@ jobs:
               "required_linear_history": true,
               "allow_force_pushes": false,
               "allow_deletions": false,
-              "required_conversation_resolution": { "enabled": true }
+              "required_conversation_resolution": true
             }
             JSON
             gh api -X POST "repos/$OWNER/$REPO/branches/$LEG/protection/required_signatures" -H "$HDR" >/dev/null || true


### PR DESCRIPTION
🛡️ **Автоматическая защита веток с ежедневной самопроверкой**

**Возможности:**
- 🔄 Применяется при каждом merge в main-clean
- 🕒 Ежедневная проверка в 03:17 UTC (06:17 IDT)
- 🧊 Попытка блокировки main-legacy через lock_branch
- 🔒 Fallback: невыполнимые требования (999 approvals)
- ✅ Полная защита main-clean с required checks

**Не требует подписи коммитов в PR** - только в main-clean!